### PR TITLE
refactor(*): code-review changes

### DIFF
--- a/__tests__/integration/main.test.ts
+++ b/__tests__/integration/main.test.ts
@@ -9,10 +9,9 @@
 import * as core from '@actions/core'
 import { context } from '@actions/github'
 import * as main from '../../src/main'
-import { titleContainsValidator } from '../../src/validators'
 
 // Mock the action's main function
-const runMock = jest.spyOn(main, 'run')
+const runMock = jest.spyOn(main, 'executeAction')
 
 // Mock the GitHub Actions core library
 let errorMock: jest.SpyInstance
@@ -34,7 +33,7 @@ describe('action', () => {
       jest.restoreAllMocks()
     })
 
-    it('succeeds if PR title contains text', async () => {
+    it('succeeds if PR title contains text', () => {
       const expectedTitleElement = 'XYZ'
 
       jest.replaceProperty(context, 'payload', {
@@ -45,7 +44,7 @@ describe('action', () => {
       })
       jest.replaceProperty(process, 'env', { ['INPUT_TITLE-CONTAINS']: expectedTitleElement })
 
-      await main.run()
+      main.executeAction()
 
       expect(runMock).toHaveReturned()
       expect(debugMock).toHaveBeenNthCalledWith(
@@ -55,7 +54,7 @@ describe('action', () => {
       expect(errorMock).not.toHaveBeenCalled()
     })
 
-    it('fails if PR title does not contain text', async () => {
+    it('fails if PR title does not contain text', () => {
       const expectedTitleElement = 'ABC'
 
       jest.replaceProperty(context, 'payload', {
@@ -66,7 +65,7 @@ describe('action', () => {
       })
       jest.replaceProperty(process, 'env', { ['INPUT_TITLE-CONTAINS']: expectedTitleElement })
 
-      await main.run()
+      main.executeAction()
 
       expect(runMock).toHaveReturned()
       expect(setFailedMock).toHaveBeenNthCalledWith(
@@ -78,7 +77,7 @@ describe('action', () => {
       expect(errorMock).not.toHaveBeenCalled()
     })
 
-    it('skips if not configured to check PR title', async () => {
+    it('skips if not configured to check PR title', () => {
       jest.replaceProperty(context, 'payload', {
         pull_request: {
           number: 1,
@@ -87,40 +86,11 @@ describe('action', () => {
       })
       jest.replaceProperty(process, 'env', {})
 
-      await main.run()
+      main.executeAction()
 
       expect(runMock).toHaveReturned()
       expect(debugMock).toHaveBeenNthCalledWith(1, expect.stringMatching(`TitleContainsValidator: skipped`))
       expect(errorMock).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('unknown action error', () => {
-    let titleValidatorMock: jest.SpyInstance
-    beforeEach(() => {
-      jest.clearAllMocks()
-      titleValidatorMock = jest.spyOn(titleContainsValidator, 'validation').mockImplementation()
-    })
-
-    afterAll(() => {
-      jest.restoreAllMocks()
-    })
-
-    it('records error', async () => {
-      titleValidatorMock.mockImplementation(() => {
-        throw new Error('Error from test mock')
-      })
-      jest.replaceProperty(context, 'payload', {
-        pull_request: {
-          number: 1,
-          title: 'PR with XYZ required'
-        }
-      })
-      jest.replaceProperty(process, 'env', { ['INPUT_TITLE-CONTAINS']: 'XYZ' })
-
-      await main.run()
-
-      expect(setFailedMock).toHaveBeenNthCalledWith(1, expect.stringMatching('Error from test mock'))
     })
   })
 
@@ -130,7 +100,7 @@ describe('action', () => {
       jest.restoreAllMocks()
     })
 
-    it('succeeds if PR title matches regex', async () => {
+    it('succeeds if PR title matches regex', () => {
       const expectedTitleRegex = 'XYZ-[0-9]+'
 
       jest.replaceProperty(context, 'payload', {
@@ -141,7 +111,7 @@ describe('action', () => {
       })
       jest.replaceProperty(process, 'env', { ['INPUT_TITLE-REGEX']: expectedTitleRegex })
 
-      await main.run()
+      main.executeAction()
 
       expect(debugMock).toHaveBeenNthCalledWith(2, expect.stringMatching(`TitleRegexValidator ✅ --- succeeded with`))
       expect(errorMock).not.toHaveBeenCalled()
@@ -154,7 +124,7 @@ describe('action', () => {
       jest.restoreAllMocks()
     })
 
-    it('succeeds if PR body contains text', async () => {
+    it('succeeds if PR body contains text', () => {
       const expectedBodyElement = 'BBODYY'
 
       jest.replaceProperty(context, 'payload', {
@@ -166,7 +136,7 @@ describe('action', () => {
       })
       jest.replaceProperty(process, 'env', { ['INPUT_BODY-CONTAINS']: expectedBodyElement })
 
-      await main.run()
+      main.executeAction()
 
       expect(debugMock).toHaveBeenNthCalledWith(
         3,
@@ -182,7 +152,7 @@ describe('action', () => {
       jest.restoreAllMocks()
     })
 
-    it('succeeds if PR body matches regex', async () => {
+    it('succeeds if PR body matches regex', () => {
       const expectedBodyRegex = 'XYZ-[0-9]+'
 
       jest.replaceProperty(context, 'payload', {
@@ -194,7 +164,7 @@ describe('action', () => {
       })
       jest.replaceProperty(process, 'env', { ['INPUT_BODY-REGEX']: expectedBodyRegex })
 
-      await main.run()
+      main.executeAction()
 
       expect(debugMock).toHaveBeenNthCalledWith(
         4,

--- a/__tests__/unit/config.test.ts
+++ b/__tests__/unit/config.test.ts
@@ -9,16 +9,23 @@ describe('buildConfigFromInput', () => {
     jest.restoreAllMocks()
   })
 
+  it('reads empty action input', () => {
+    const config = buildConfigFromInput()
+    expect(config).toEqual({
+      titleContains: '',
+      titleRegex: '',
+      bodyContains: '',
+      bodyRegex: ''
+    })
+  })
+
   it('reads titleContains from action input', () => {
     jest.replaceProperty(process, 'env', { ['INPUT_TITLE-CONTAINS']: 'ABC' })
 
     const config = buildConfigFromInput()
 
-    expect(config).toEqual({
-      titleContains: 'ABC',
-      titleRegex: null,
-      bodyContains: null,
-      bodyRegex: null
+    expect(config).toMatchObject({
+      titleContains: 'ABC'
     })
   })
 
@@ -27,11 +34,8 @@ describe('buildConfigFromInput', () => {
 
     const config = buildConfigFromInput()
 
-    expect(config).toEqual({
-      titleContains: null,
-      titleRegex: '^[a-z]{3}.*$',
-      bodyContains: null,
-      bodyRegex: null
+    expect(config).toMatchObject({
+      titleRegex: '^[a-z]{3}.*$'
     })
   })
 
@@ -40,11 +44,8 @@ describe('buildConfigFromInput', () => {
 
     const config = buildConfigFromInput()
 
-    expect(config).toEqual({
-      titleContains: null,
-      titleRegex: null,
-      bodyContains: 'BBOODDYY',
-      bodyRegex: null
+    expect(config).toMatchObject({
+      bodyContains: 'BBOODDYY'
     })
   })
 
@@ -53,10 +54,7 @@ describe('buildConfigFromInput', () => {
 
     const config = buildConfigFromInput()
 
-    expect(config).toEqual({
-      titleContains: null,
-      titleRegex: null,
-      bodyContains: null,
+    expect(config).toMatchObject({
       bodyRegex: 'XYZ-\\d+'
     })
   })

--- a/__tests__/unit/index.test.ts
+++ b/__tests__/unit/index.test.ts
@@ -2,16 +2,31 @@
  * Unit tests for the action's entrypoint, src/index.ts
  */
 
+import * as core from '@actions/core'
 import * as main from '../../src/main'
 
 // Mock the action's entrypoint
-const runMock = jest.spyOn(main, 'run').mockImplementation()
+const executeActionMock = jest.spyOn(main, 'executeAction').mockImplementation()
+const setFailedMock = jest.spyOn(core, 'setFailed').mockImplementation()
 
 describe('index', () => {
-  it('calls run when imported', async () => {
+  it('calls run when imported', () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     require('../../src/index')
 
-    expect(runMock).toHaveBeenCalled()
+    expect(executeActionMock).toHaveBeenCalled()
+  })
+
+  describe('error handling', () => {
+    it('records error', async () => {
+      executeActionMock.mockImplementation(() => {
+        throw new Error('Error from test mock')
+      })
+
+      // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+      await require('../../src/index').run()
+
+      expect(setFailedMock).toHaveBeenNthCalledWith(1, expect.stringMatching('Error from test mock'))
+    })
   })
 })

--- a/__tests__/unit/validators.test.ts
+++ b/__tests__/unit/validators.test.ts
@@ -9,17 +9,10 @@ import {
   titleRegexValidator
 } from '../../src/validators'
 
-const emptyConfig = {
-  titleContains: null,
-  titleRegex: null,
-  bodyContains: null,
-  bodyRegex: null
-}
-
 describe('titleValidator', () => {
   describe('when titleContains was not defined', () => {
     it('returns skipped validation result', () => {
-      const config = emptyConfig
+      const config = {}
       const pullRequest = { title: 'test title' }
       expect(titleContainsValidator.validation(config, pullRequest)).toEqual({
         skipped: true
@@ -30,10 +23,9 @@ describe('titleValidator', () => {
   describe('when titleContains was defined', () => {
     describe('when it matches', () => {
       it('returns successful validation result', () => {
-        const config = { ...emptyConfig, titleContains: 'ABC' }
+        const config = { titleContains: 'ABC' }
         const pullRequest = { title: 'test title ABC' }
         expect(titleContainsValidator.validation(config, pullRequest)).toEqual({
-          skipped: false,
           success: true,
           message: 'PR Title contains ABC'
         })
@@ -42,11 +34,9 @@ describe('titleValidator', () => {
 
     describe('when it does not match', () => {
       it('returns failed validation result', () => {
-        const config = { ...emptyConfig, titleContains: 'ABC' }
+        const config = { titleContains: 'ABC' }
         const pullRequest = { title: 'test title XYZ' }
         expect(titleContainsValidator.validation(config, pullRequest)).toEqual({
-          skipped: false,
-          success: false,
           message: 'PR Title does not contain ABC'
         })
       })
@@ -57,7 +47,7 @@ describe('titleValidator', () => {
 describe('titleRegex', () => {
   describe('when titleRegex was not defined', () => {
     it('returns skipped validation result', () => {
-      const config = emptyConfig
+      const config = {}
       const pullRequest = { title: 'test title' }
       expect(titleRegexValidator.validation(config, pullRequest)).toEqual({
         skipped: true
@@ -68,10 +58,9 @@ describe('titleRegex', () => {
   describe('when titleContains was defined', () => {
     describe('when it matches', () => {
       it('returns successful validation result', () => {
-        const config = { ...emptyConfig, titleRegex: '^abc-[ab]{3}-.....$' }
+        const config = { titleRegex: '^abc-[ab]{3}-.....$' }
         const pullRequest = { title: 'abc-abb-12345' }
         expect(titleRegexValidator.validation(config, pullRequest)).toEqual({
-          skipped: false,
           success: true,
           message: 'PR Title matches ^abc-[ab]{3}-.....$'
         })
@@ -80,11 +69,9 @@ describe('titleRegex', () => {
 
     describe('when it does not match', () => {
       it('returns failed validation result', () => {
-        const config = { ...emptyConfig, titleRegex: '^abc-[ab]{3}-.....$' }
+        const config = { titleRegex: '^abc-[ab]{3}-.....$' }
         const pullRequest = { title: 'test title XYZ' }
         expect(titleRegexValidator.validation(config, pullRequest)).toEqual({
-          skipped: false,
-          success: false,
           message: 'PR Title does not match ^abc-[ab]{3}-.....$'
         })
       })
@@ -95,7 +82,7 @@ describe('titleRegex', () => {
 describe('bodyContains', () => {
   describe('when bodyContains was not defined', () => {
     it('returns skipped validation result', () => {
-      const config = { ...emptyConfig, titleRegex: null }
+      const config = {}
       const pullRequest = { title: 'test title', body: 'test body' }
       expect(bodyContainsValidator.validation(config, pullRequest)).toEqual({
         skipped: true
@@ -106,13 +93,12 @@ describe('bodyContains', () => {
   describe('when titleContains was defined', () => {
     describe('when it matches', () => {
       it('returns successful validation result', () => {
-        const config = { ...emptyConfig, bodyContains: 'BBOODDYY' }
+        const config = { bodyContains: 'BBOODDYY' }
         const pullRequest = {
           title: 'abc-abb-12345',
           body: 'Long text\nwith newlines\n but contains BBOODDYY\n somewhere'
         }
         expect(bodyContainsValidator.validation(config, pullRequest)).toEqual({
-          skipped: false,
           success: true,
           message: 'PR Body contains BBOODDYY'
         })
@@ -122,11 +108,9 @@ describe('bodyContains', () => {
     describe('when it does not match', () => {
       describe('when body is empty', () => {
         it('returns failed validation result', () => {
-          const config = { ...emptyConfig, bodyContains: 'BBOODDYY' }
+          const config = { bodyContains: 'BBOODDYY' }
           const pullRequest = { title: 'test title XYZ' }
           expect(bodyContainsValidator.validation(config, pullRequest)).toEqual({
-            skipped: false,
-            success: false,
             message: 'PR Body does not contain BBOODDYY'
           })
         })
@@ -134,14 +118,12 @@ describe('bodyContains', () => {
 
       describe('when body is not empty', () => {
         it('returns failed validation result', () => {
-          const config = { ...emptyConfig, bodyContains: 'BBOODDYY' }
+          const config = { bodyContains: 'BBOODDYY' }
           const pullRequest = {
             title: 'test title XYZ',
             body: 'Long text\nwith newlines\n but does not contain B-B-O-ODD-YY\n somewhere'
           }
           expect(bodyContainsValidator.validation(config, pullRequest)).toEqual({
-            skipped: false,
-            success: false,
             message: 'PR Body does not contain BBOODDYY'
           })
         })
@@ -153,7 +135,7 @@ describe('bodyContains', () => {
 describe('bodyRegexValidator', () => {
   describe('when bodyRegex was not defined', () => {
     it('returns skipped validation result', () => {
-      const config = emptyConfig
+      const config = {}
       const pullRequest = { title: 'test title', body: 'test body' }
       expect(bodyRegexValidator.validation(config, pullRequest)).toEqual({
         skipped: true
@@ -164,13 +146,12 @@ describe('bodyRegexValidator', () => {
   describe('when bodyRegex was defined', () => {
     describe('when it matches', () => {
       it('returns successful validation result', () => {
-        const config = { ...emptyConfig, bodyRegex: 'Ticket: XYZ-\\d+' }
+        const config = { bodyRegex: 'Ticket: XYZ-\\d+' }
         const pullRequest = {
           title: 'abc-abb-12345',
           body: 'Long text\nwith newlines\n but contains Ticket: XYZ-12345\n somewhere'
         }
         expect(bodyRegexValidator.validation(config, pullRequest)).toEqual({
-          skipped: false,
           success: true,
           message: 'PR Body matches Ticket: XYZ-\\d+'
         })
@@ -180,13 +161,11 @@ describe('bodyRegexValidator', () => {
     describe('when it does not match', () => {
       describe('when body is empty', () => {
         it('returns failed validation result', () => {
-          const config = { ...emptyConfig, bodyRegex: 'Ticket: XYZ-\\d+' }
+          const config = { bodyRegex: 'Ticket: XYZ-\\d+' }
           const pullRequest = {
             title: 'abc-abb-12345'
           }
           expect(bodyRegexValidator.validation(config, pullRequest)).toEqual({
-            skipped: false,
-            success: false,
             message: 'PR Body does not match Ticket: XYZ-\\d+'
           })
         })
@@ -194,14 +173,12 @@ describe('bodyRegexValidator', () => {
 
       describe('when body is not empty', () => {
         it('returns failed validation result', () => {
-          const config = { ...emptyConfig, bodyRegex: 'Ticket: XYZ-\\d+' }
+          const config = { bodyRegex: 'Ticket: XYZ-\\d+' }
           const pullRequest = {
             title: 'abc-abb-12345',
             body: 'Long text\nwith newlines\n but does not contain Ticket: UUU-12345\n somewhere'
           }
           expect(bodyRegexValidator.validation(config, pullRequest)).toEqual({
-            skipped: false,
-            success: false,
             message: 'PR Body does not match Ticket: XYZ-\\d+'
           })
         })

--- a/dist/index.js
+++ b/dist/index.js
@@ -28937,20 +28937,64 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.buildConfigFromInput = void 0;
 const core = __importStar(__nccwpck_require__(2186));
-const nullOr = (v) => (v === '' ? null : v);
-const buildConfigFromInput = () => {
-    const inputTitleContains = core.getInput('title-contains');
-    const inputTitleRegex = core.getInput('title-regex');
-    const inputBodyContains = core.getInput('body-contains');
-    const inputBodyRegex = core.getInput('body-regex');
-    return {
-        titleContains: nullOr(inputTitleContains),
-        titleRegex: nullOr(inputTitleRegex),
-        bodyContains: nullOr(inputBodyContains),
-        bodyRegex: nullOr(inputBodyRegex)
-    };
-};
+const buildConfigFromInput = () => ({
+    titleContains: core.getInput('title-contains'),
+    titleRegex: core.getInput('title-regex'),
+    bodyContains: core.getInput('body-contains'),
+    bodyRegex: core.getInput('body-regex')
+});
 exports.buildConfigFromInput = buildConfigFromInput;
+
+
+/***/ }),
+
+/***/ 6144:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.run = void 0;
+/**
+ * The entrypoint for the action.
+ */
+const core = __importStar(__nccwpck_require__(2186));
+const main_1 = __nccwpck_require__(399);
+async function run() {
+    try {
+        (0, main_1.executeAction)();
+    }
+    catch (error) {
+        if (error instanceof Error)
+            core.setFailed(error.message);
+    }
+}
+exports.run = run;
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+run();
 
 
 /***/ }),
@@ -28984,7 +29028,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.run = void 0;
+exports.executeAction = void 0;
 const core = __importStar(__nccwpck_require__(2186));
 const config_1 = __nccwpck_require__(6373);
 const pull_request_1 = __nccwpck_require__(4773);
@@ -29002,24 +29046,14 @@ const processResult = (validatorName, result) => {
         }
     }
 };
-/**
- * The main function for the action.
- * @returns {Promise<void>} Resolves when the action is complete.
- */
-async function run() {
-    try {
-        const config = (0, config_1.buildConfigFromInput)();
-        const pr = (0, pull_request_1.getPullRequestFromContext)();
-        const runValidation = (0, validators_1.validationRunner)(config, pr, processResult);
-        const validators = [validators_1.titleContainsValidator, validators_1.titleRegexValidator, validators_1.bodyContainsValidator, validators_1.bodyRegexValidator];
-        validators.forEach(runValidation);
-    }
-    catch (error) {
-        if (error instanceof Error)
-            core.setFailed(error.message);
-    }
-}
-exports.run = run;
+const executeAction = () => {
+    const config = (0, config_1.buildConfigFromInput)();
+    const pr = (0, pull_request_1.getPullRequestFromContext)();
+    const runValidation = (0, validators_1.validationRunner)(config, pr, processResult);
+    const validators = [validators_1.titleContainsValidator, validators_1.titleRegexValidator, validators_1.bodyContainsValidator, validators_1.bodyRegexValidator];
+    validators.forEach(runValidation);
+};
+exports.executeAction = executeAction;
 
 
 /***/ }),
@@ -29033,12 +29067,12 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getPullRequestFromContext = void 0;
 const github_1 = __nccwpck_require__(5438);
 const getPullRequestFromContext = () => {
-    if (github_1.context.payload.pull_request === undefined) {
+    if (!github_1.context.payload.pull_request) {
         throw new Error('The action does not run in pull request context!');
     }
     const title = github_1.context.payload.pull_request.title;
     const body = github_1.context.payload.pull_request.body;
-    if (title === undefined) {
+    if (!title) {
         throw new Error('Pull request does not have a title!');
     }
     return {
@@ -29064,7 +29098,7 @@ exports.validationRunner = validationRunner;
 exports.titleContainsValidator = {
     name: 'TitleContainsValidator',
     validation: (config, pullRequest) => {
-        if (config.titleContains === null) {
+        if (!config.titleContains) {
             return {
                 skipped: true
             };
@@ -29072,13 +29106,10 @@ exports.titleContainsValidator = {
         if (pullRequest.title.includes(config.titleContains)) {
             return {
                 success: true,
-                skipped: false,
                 message: `PR Title contains ${config.titleContains}`
             };
         }
         return {
-            success: false,
-            skipped: false,
             message: `PR Title does not contain ${config.titleContains}`
         };
     }
@@ -29086,7 +29117,7 @@ exports.titleContainsValidator = {
 exports.titleRegexValidator = {
     name: 'TitleRegexValidator',
     validation: (config, pullRequest) => {
-        if (config.titleRegex === null) {
+        if (!config.titleRegex) {
             return {
                 skipped: true
             };
@@ -29095,13 +29126,10 @@ exports.titleRegexValidator = {
             if (pullRequest.title.match(config.titleRegex)) {
                 return {
                     success: true,
-                    skipped: false,
                     message: `PR Title matches ${config.titleRegex}`
                 };
             }
             return {
-                success: false,
-                skipped: false,
                 message: `PR Title does not match ${config.titleRegex}`
             };
         }
@@ -29110,22 +29138,19 @@ exports.titleRegexValidator = {
 exports.bodyContainsValidator = {
     name: 'BodyContainsValidator',
     validation: (config, pullRequest) => {
-        if (config.bodyContains === null) {
+        if (!config.bodyContains) {
             return {
                 skipped: true
             };
         }
         else {
-            if (pullRequest.body && pullRequest.body.includes(config.bodyContains)) {
+            if (pullRequest?.body?.includes(config.bodyContains)) {
                 return {
                     success: true,
-                    skipped: false,
                     message: `PR Body contains ${config.bodyContains}`
                 };
             }
             return {
-                success: false,
-                skipped: false,
                 message: `PR Body does not contain ${config.bodyContains}`
             };
         }
@@ -29134,22 +29159,19 @@ exports.bodyContainsValidator = {
 exports.bodyRegexValidator = {
     name: 'BodyRegexValidator',
     validation: (config, pullRequest) => {
-        if (config.bodyRegex === null) {
+        if (!config.bodyRegex) {
             return {
                 skipped: true
             };
         }
         else {
-            if (pullRequest.body && pullRequest.body.match(config.bodyRegex)) {
+            if (pullRequest?.body?.match(config.bodyRegex)) {
                 return {
                     success: true,
-                    skipped: false,
                     message: `PR Body matches ${config.bodyRegex}`
                 };
             }
             return {
-                success: false,
-                skipped: false,
                 message: `PR Body does not match ${config.bodyRegex}`
             };
         }
@@ -31040,22 +31062,12 @@ module.exports = parseParams
 /******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
 /******/ 	
 /************************************************************************/
-var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be in strict mode.
-(() => {
-"use strict";
-var exports = __webpack_exports__;
-
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-/**
- * The entrypoint for the action.
- */
-const main_1 = __nccwpck_require__(399);
-// eslint-disable-next-line @typescript-eslint/no-floating-promises
-(0, main_1.run)();
-
-})();
-
-module.exports = __webpack_exports__;
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module is referenced by other modules so it can't be inlined
+/******/ 	var __webpack_exports__ = __nccwpck_require__(6144);
+/******/ 	module.exports = __webpack_exports__;
+/******/ 	
 /******/ })()
 ;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,24 +1,15 @@
 import * as core from '@actions/core'
 
 export interface Config {
-  titleContains: string | null
-  titleRegex: string | null
-  bodyContains: string | null
-  bodyRegex: string | null
+  titleContains?: string
+  titleRegex?: string
+  bodyContains?: string
+  bodyRegex?: string
 }
 
-const nullOr = (v: string): string | null => (v === '' ? null : v)
-
-export const buildConfigFromInput = (): Config => {
-  const inputTitleContains = core.getInput('title-contains')
-  const inputTitleRegex = core.getInput('title-regex')
-  const inputBodyContains = core.getInput('body-contains')
-  const inputBodyRegex = core.getInput('body-regex')
-
-  return {
-    titleContains: nullOr(inputTitleContains),
-    titleRegex: nullOr(inputTitleRegex),
-    bodyContains: nullOr(inputBodyContains),
-    bodyRegex: nullOr(inputBodyRegex)
-  }
-}
+export const buildConfigFromInput = (): Config => ({
+  titleContains: core.getInput('title-contains'),
+  titleRegex: core.getInput('title-regex'),
+  bodyContains: core.getInput('body-contains'),
+  bodyRegex: core.getInput('body-regex')
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,16 @@
 /**
  * The entrypoint for the action.
  */
-import { run } from './main'
+import * as core from '@actions/core'
+import { executeAction } from './main'
+
+export async function run(): Promise<void> {
+  try {
+    executeAction()
+  } catch (error) {
+    if (error instanceof Error) core.setFailed(error.message)
+  }
+}
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
 run()

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,20 +22,12 @@ const processResult = (validatorName: string, result: ValidationResult): void =>
   }
 }
 
-/**
- * The main function for the action.
- * @returns {Promise<void>} Resolves when the action is complete.
- */
-export async function run(): Promise<void> {
-  try {
-    const config = buildConfigFromInput()
-    const pr = getPullRequestFromContext()
-    const runValidation = validationRunner(config, pr, processResult)
+export const executeAction = (): void => {
+  const config = buildConfigFromInput()
+  const pr = getPullRequestFromContext()
+  const runValidation = validationRunner(config, pr, processResult)
 
-    const validators = [titleContainsValidator, titleRegexValidator, bodyContainsValidator, bodyRegexValidator]
+  const validators = [titleContainsValidator, titleRegexValidator, bodyContainsValidator, bodyRegexValidator]
 
-    validators.forEach(runValidation)
-  } catch (error) {
-    if (error instanceof Error) core.setFailed(error.message)
-  }
+  validators.forEach(runValidation)
 }

--- a/src/pull-request.ts
+++ b/src/pull-request.ts
@@ -6,14 +6,14 @@ export interface PullRequest {
 }
 
 export const getPullRequestFromContext = (): PullRequest => {
-  if (context.payload.pull_request === undefined) {
+  if (!context.payload.pull_request) {
     throw new Error('The action does not run in pull request context!')
   }
 
   const title = context.payload.pull_request.title
   const body = context.payload.pull_request.body
 
-  if (title === undefined) {
+  if (!title) {
     throw new Error('Pull request does not have a title!')
   }
 

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -1,17 +1,12 @@
 import { Config } from './config'
 import { PullRequest } from './pull-request'
 
-export interface SkippedValidation {
-  skipped: true
+export interface ValidationResult {
+  success?: boolean
+  skipped?: boolean
+  message?: string
 }
 
-export interface ExecutedValidation {
-  success: boolean
-  skipped: false
-  message: string
-}
-
-export type ValidationResult = SkippedValidation | ExecutedValidation
 type ResultProcessor = (validatorName: string, result: ValidationResult) => void
 
 export interface Validator {
@@ -28,7 +23,7 @@ export const validationRunner =
 export const titleContainsValidator: Validator = {
   name: 'TitleContainsValidator',
   validation: (config: Config, pullRequest: PullRequest): ValidationResult => {
-    if (config.titleContains === null) {
+    if (!config.titleContains) {
       return {
         skipped: true
       }
@@ -37,14 +32,11 @@ export const titleContainsValidator: Validator = {
     if (pullRequest.title.includes(config.titleContains)) {
       return {
         success: true,
-        skipped: false,
         message: `PR Title contains ${config.titleContains}`
       }
     }
 
     return {
-      success: false,
-      skipped: false,
       message: `PR Title does not contain ${config.titleContains}`
     }
   }
@@ -53,7 +45,7 @@ export const titleContainsValidator: Validator = {
 export const titleRegexValidator: Validator = {
   name: 'TitleRegexValidator',
   validation: (config: Config, pullRequest: PullRequest): ValidationResult => {
-    if (config.titleRegex === null) {
+    if (!config.titleRegex) {
       return {
         skipped: true
       }
@@ -61,14 +53,11 @@ export const titleRegexValidator: Validator = {
       if (pullRequest.title.match(config.titleRegex)) {
         return {
           success: true,
-          skipped: false,
           message: `PR Title matches ${config.titleRegex}`
         }
       }
 
       return {
-        success: false,
-        skipped: false,
         message: `PR Title does not match ${config.titleRegex}`
       }
     }
@@ -78,22 +67,19 @@ export const titleRegexValidator: Validator = {
 export const bodyContainsValidator: Validator = {
   name: 'BodyContainsValidator',
   validation: (config: Config, pullRequest: PullRequest): ValidationResult => {
-    if (config.bodyContains === null) {
+    if (!config.bodyContains) {
       return {
         skipped: true
       }
     } else {
-      if (pullRequest.body && pullRequest.body.includes(config.bodyContains)) {
+      if (pullRequest?.body?.includes(config.bodyContains)) {
         return {
           success: true,
-          skipped: false,
           message: `PR Body contains ${config.bodyContains}`
         }
       }
 
       return {
-        success: false,
-        skipped: false,
         message: `PR Body does not contain ${config.bodyContains}`
       }
     }
@@ -103,22 +89,19 @@ export const bodyContainsValidator: Validator = {
 export const bodyRegexValidator: Validator = {
   name: 'BodyRegexValidator',
   validation: (config: Config, pullRequest: PullRequest): ValidationResult => {
-    if (config.bodyRegex === null) {
+    if (!config.bodyRegex) {
       return {
         skipped: true
       }
     } else {
-      if (pullRequest.body && pullRequest.body.match(config.bodyRegex)) {
+      if (pullRequest?.body?.match(config.bodyRegex)) {
         return {
           success: true,
-          skipped: false,
           message: `PR Body matches ${config.bodyRegex}`
         }
       }
 
       return {
-        success: false,
-        skipped: false,
         message: `PR Body does not match ${config.bodyRegex}`
       }
     }


### PR DESCRIPTION
### Summary

Code review changes: 

- prefer `?.` instead of checking for property existence
- move error handling of failed action to another file
- do not compare explicitly to `=== undefined` or `=== false` - prefer `!value`
- remove `{ variable: false }` assignments - prefer falsy (absence)


### Issue Tracker

KAG-3589